### PR TITLE
fix(live): apply RBP overlay in default_trade_size single chokepoint

### DIFF
--- a/src/backtest/executor.py
+++ b/src/backtest/executor.py
@@ -127,6 +127,7 @@ class BacktestExecutor:
 
     def default_trade_size(
         self,
+        portfolio_id,
         signal_type,
         ticker,
         arrival_price,
@@ -138,7 +139,9 @@ class BacktestExecutor:
     ):
         """Size a trade with the default target-weight model, without filling.
 
-        Single sizing entry point for both the OMS path (which reads
+        ``portfolio_id`` is accepted for signature parity with the live executor
+        (where it keys the RBP overlay); the backtest has no overlay and ignores
+        it. Single sizing entry point for both the OMS path (which reads
         ``.quantity`` to register a parent order) and ``execute_trade`` (which
         also needs ``.desired_notional`` for BUY/SELL direction and
         ``.exec_price`` for the fill). Returns a ``Sizing`` with ``quantity == 0``
@@ -238,6 +241,7 @@ class BacktestExecutor:
         # Size with the shared default model (handles coercion, signal/price
         # validation, equal-weight fallback, and buying-power/cash constraints).
         sizing = self.default_trade_size(
+            portfolio_id=portfolio_id,
             signal_type=signal_type,
             ticker=ticker,
             arrival_price=arrival_price,

--- a/src/live_trading/executor.py
+++ b/src/live_trading/executor.py
@@ -84,6 +84,7 @@ class tradeExecutor:
 
     def default_trade_size(
         self,
+        portfolio_id,
         signal_type,
         ticker,
         arrival_price,
@@ -100,7 +101,9 @@ class tradeExecutor:
         also needs ``.desired_notional`` for BUY/SELL direction and
         ``.exec_price`` for the fill). Fetches the live price once so
         ``execute_trade`` reuses it rather than re-fetching. Returns a ``Sizing``
-        with ``quantity == 0`` on any no-trade.
+        with ``quantity == 0`` on any no-trade. This is also the single
+        chokepoint for the RBP conviction overlay, so every sizing path (direct
+        fill and OMS) blends confidence identically.
         """
         try:
             cash_val = float(cash)
@@ -116,6 +119,31 @@ class tradeExecutor:
         if signal_type not in ("BUY", "SELL", "HOLD"):
             self.logger.debug("Skip trade: unsupported signal_type=%s", signal_type)
             return Sizing(0, 0.0, 0.0)
+
+        # RBP conviction overlay (single chokepoint for all portfolios and both
+        # the direct-fill and OMS paths). Never propagates errors — a failing
+        # overlay falls back to the raw confidence.
+        if self.rbp_overlay is not None:
+            try:
+                confidence_val = max(
+                    0.0,
+                    min(
+                        1.0,
+                        float(
+                            self.rbp_overlay(
+                                portfolio_id, ticker, signal_type, confidence_val
+                            )
+                        ),
+                    ),
+                )
+            except Exception as exc:
+                self.logger.warning(
+                    "RBP overlay raised unexpectedly for %s/%s: %s",
+                    portfolio_id,
+                    ticker,
+                    exc,
+                )
+
         if signal_type == "HOLD" or confidence_val == 0.0:
             self.logger.debug(
                 "Skip trade: signal=%s confidence=%.2f", signal_type, confidence_val
@@ -201,9 +229,11 @@ class tradeExecutor:
         Sizes the trade with the shared default model and, on a non-zero
         quantity, settles it through the database. Sizing (coercion, signal/price
         validation, buying power, live price fetch) lives in default_trade_size;
-        this method owns only the fill and DB bookkeeping.
+        this method owns only the fill and DB bookkeeping. Confidence blending
+        (RBP overlay) happens inside default_trade_size, the shared chokepoint.
         """
         sizing = self.default_trade_size(
+            portfolio_id=portfolio_id,
             signal_type=signal_type,
             ticker=ticker,
             arrival_price=arrival_price,

--- a/src/portfolios/order_interface.py
+++ b/src/portfolios/order_interface.py
@@ -100,6 +100,7 @@ class StrategyContext:
             # OMS path: size with the executor's default model, then register the
             # order with the OMS (which owns execution from here).
             sizing = self._executor.default_trade_size(
+                portfolio_id=self._portfolio_config["id"],
                 signal_type=signal_type,
                 ticker=ticker,
                 arrival_price=asset_data.Close,


### PR DESCRIPTION
## Problem
The `winter_dev` → `dev` merge left the live executor **accepting and storing `rbp_overlay` but never applying it**. The sizing-method body was resolved toward the winter_dev side (which had no overlay), so live signal confidence flowed through **unblended** and the RBP conviction overlay was silently dead — `tradeExecutor` logs `RBP overlay: enabled` but the blend never happens.

Caught by `tests/integration/test_rbp_end_to_end.py` once it became collectable again (`qty=5000` raw vs `5261` blended).

## Fix
Restore the overlay at the **single chokepoint** (`default_trade_size`) so every sizing path blends confidence identically:

- **live executor**: apply the overlay inside `default_trade_size` (now takes `portfolio_id`); `execute_trade` just threads `portfolio_id` through. Both the direct-fill and OMS paths funnel through this one place, so **OMS parent orders no longer carry raw (un-blended) confidence**.
- **`order_interface`** (shared seam): OMS path passes `portfolio_id` into `default_trade_size`.
- **backtest executor**: `default_trade_size` accepts `portfolio_id` for signature parity (no overlay in backtest; accepted and ignored).

Overlay failures still fall back to raw confidence (never propagate).

## Verification
- Live suite **45/45** (incl. `test_rbp_end_to_end`)
- Smoke gate **24/24**, exact CI gate (`smoke and workflow_backtest`) green
- Ruff F821/F811 clean on all changed files
- `python -m src.main_backtest` runs end-to-end including the OMS order path

🤖 Generated with [Claude Code](https://claude.com/claude-code)