### PR TITLE
fix(deploy): remove job-level concurrency that deadlocked the deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,12 @@ env:
 permissions:
   contents: read
 
+# Serialize deploys per ref, and never cancel one in flight -- an interrupted
+# run can leave an image in ECR with no matching task definition revision.
+#
+# This must stay workflow-level ONLY. A job-level `concurrency:` with this same
+# group deadlocks: the job cannot acquire a group its own workflow run already
+# holds, and GitHub fails it in about a second with no steps and no logs.
 concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: false
@@ -48,8 +54,6 @@ jobs:
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_branch == 'main')
-    concurrency:
-      group: deploy-${{ github.ref }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## What broke

The first real run of `deploy.yml` — [31975991216](https://github.com/MUNQuantSociety/MQSMaster/actions/runs/31975991216), triggered by `workflow_run` on the #46 merge — failed in **one second** with zero steps recorded, no logs, and no annotations.

Cause: the same concurrency group declared at both workflow and job scope.

```yaml
concurrency:                      # workflow scope
  group: deploy-${{ github.ref }}

jobs:
  deploy:
    concurrency:                  # job scope -- same group
      group: deploy-${{ github.ref }}
```

A job cannot acquire a concurrency group its own workflow run already holds. GitHub fails the job outright instead of deadlocking, which is why there is nothing in the logs to read.

The guard arrived in `cf151df` and was never exercised — the workflow was `workflow_dispatch`-only and had never been run. Wiring the `workflow_run` trigger in #46 is what finally executed it.

## Fix

Drop the job-level duplicate. Keep the workflow-level group: serializing deploys per ref with `cancel-in-progress: false` is correct, since an interrupted run can leave an image in ECR with no matching task definition revision. Added a comment so it does not come back.

## Blast radius of the failed run

None. Verified directly against the account:

- No SHA-tagged image in ECR — newest is `1.0.5-7`, pushed 09:35 by the Image Builder pipeline, unrelated
- `mqsmaster-prod` still at **revision 2**, image `livetradingbot:1.0.5-6`

The job died before its first step, so it never reached the ECR push or the task-definition register.

## After this merges

`AWS_DEPLOY_ROLE_ARN` is now set, so merging this triggers `main.yml` → `deploy.yml` and the deploy will attempt for real: ECR push plus a new `mqsmaster-prod` revision. The `mqsmaster-prod-market-open` schedule targets the family unpinned, so the new revision takes effect at the next weekday 09:30 ET run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)